### PR TITLE
Add author to cookiecutter.json

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,6 @@
   "project_name": "Binary Threshold",
   "project_slug": "threshold",
   "project_url": "https://github.com/scikit-image/scikit-image",
+  "author": "John Doe",
   "python_version": "3.9"
 }


### PR DESCRIPTION
The cookiecutter fails because author is required in the `metadata.yml `file. This fixes it by requesting the author name from the user.